### PR TITLE
Long press delay

### DIFF
--- a/listen-for-shutdown.py
+++ b/listen-for-shutdown.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python
 
-
 import RPi.GPIO as GPIO
 import subprocess
+import time
+from time import sleep
 
+gpio_pin=3
+long_press=30
 
 GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.wait_for_edge(3, GPIO.FALLING)
+GPIO.setup(gpio_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-subprocess.call(['shutdown', '-h', 'now'], shell=False)
+def main():
+  while True:
+    GPIO.wait_for_edge(gpio_pin, GPIO.FALLING)
+    counter = 0
+    while GPIO.input(gpio_pin) == 0 and counter < long_press:
+      time.sleep(0.1)
+      counter += 1
+      print('Shutdown button is pressed ' + str(counter))
+    if counter >= long_press:
+      print('Shutting down')
+      subprocess.call(['shutdown', '-h', 'now'], shell=False)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Add long_press delay to prevent inadvertent shutdowns.
Variable long_press can be set to number of 0.1 s intervals (10 for 1 s, 30 for 3s, etc.), defining how long user have to keep button pressed to shutdown Raspberry Pi. If set to 0 - button press would execute shutdown command immediately